### PR TITLE
Fix

### DIFF
--- a/app/i18n.js
+++ b/app/i18n.js
@@ -12,7 +12,7 @@ i18n
   .use(i18nextXHR)
   .init({
     backend: {
-      loadPath: language => `./content/i18n/${language}.json`,
+      loadPath: language => `/content/i18n/${language}.json`,
       allowMultiLoading: false,
       queryStringParams: {
         v: __webpack_hash__
@@ -24,7 +24,6 @@ i18n
     ns: NAMESPACES,
     defaultNS: DEFAULTNAMESPACE,
     debug: false,
-    keySeparator: false,
     interpolation: {
       escapeValue: false,
       formatSeparator: ','


### PR DESCRIPTION
When router is used the request to get language was with wrong url (404). Now to url is from the root page and not from relative path.
Inte provious version when you tried to translate some key like "menu.home", the key was not found because there was a flag "keySeparator" to false, no i have removed.